### PR TITLE
Get property error

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -168,7 +168,7 @@ class Component {
         }
       }
 
-      throw new Error('Property not found.')
+      throw new Error(`Property ${property} not found.`)
     } else {
       throw new Error('Property should be an instance of property class.')
     }

--- a/src/Port.js
+++ b/src/Port.js
@@ -141,7 +141,7 @@ class Port {
         }
       }
 
-      throw new Error('Property not found.')
+      throw new Error(`Property ${property} not found.`)
     } else {
       throw new Error('Property should be an instance of property class.')
     }


### PR DESCRIPTION
#### Description:
This PR adds the name of the property whose lookup failed in the `getProperty()` method, to the error message thrown.
#### Fix:
This PR replaces the existing `Property not found` error message with `Property property_name not found` in the `getProperty()` methods for `Component.js` and `Port.js`.
#### Rationale:
When building graph components, a developer often adds multiple properties to `Component` and/or `Port`. Sometimes, when executing the components or as in my case, testing them, a developer might send wrong property names that are not the ones the component expects.
This PR makes the error clearer by outputting the offending property name, thus making the error easier to debug and fix.