### PR TITLE
Component property method errors

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -75,14 +75,14 @@ class Component {
         this.addProperty(properties[i])
       }
     } else {
-      throw new Error('propertys should be an instance of Property class.')
+      throw new Error(`Property ${property} should be an instance of property class.`)
     }
   }
 
   addProperty(property) {
     if (property instanceof Property) {
       if (!property.id) {
-        throw new Error('Property does not have an ID.')
+        throw new Error(`Property ${property} does not have an ID.`)
       }
 
       for (let i = 0; i < this._propertys.length; i++) {
@@ -90,20 +90,20 @@ class Component {
           property.name === this._propertys[i].name ||
           property.id === this._propertys[i].id
         ) {
-          throw new Error('Property with the same name or id already exists.')
+          throw new Error(`Property with the same name or id as ${property} already exists.`)
         }
       }
 
       this._propertys.push(property)
     } else {
-      throw new Error('propertys should be an instance of Property class.')
+      throw new Error(`Property ${property} should be an instance of Property class.`)
     }
   }
 
   removeProperty(property) {
     if (property instanceof Property || typeof property === 'string') {
       if (property instanceof Property && !property.id) {
-        throw new Error('Property does not have an ID.')
+        throw new Error(`Property ${property} does not have an ID.`)
       }
 
       for (let i = 0; i < this._propertys.length; i++) {
@@ -121,14 +121,14 @@ class Component {
         }
       }
     } else {
-      throw new Error('propertys should be an instance of Property class.')
+      throw new Error(`Property ${property} should be an instance of Property class.`)
     }
   }
 
   updateProperty(property) {
     if (property instanceof Property) {
       if (!property.id) {
-        throw new Error('Property does not have an ID.')
+        throw new Error(`Property ${property} does not have an ID.`)
       }
 
       for (let i = 0; i < this._propertys.length; i++) {
@@ -141,16 +141,16 @@ class Component {
         }
       }
 
-      throw new Error('Property not found and is not updated.')
+      throw new Error(`Property ${property} not found and is not updated.`)
     } else {
-      throw new Error('propertys should be an instance of Property class.')
+      throw new Error(`Property ${property} should be an instance of Property class.`)
     }
   }
 
   getProperty(property) {
     if (property instanceof Property || typeof property === 'string') {
       if (property instanceof Property && !property.id) {
-        throw new Error('Property does not have an ID.')
+        throw new Error(`Property ${property} does not have an ID.`)
       }
 
       for (let i = 0; i < this._propertys.length; i++) {
@@ -168,16 +168,16 @@ class Component {
         }
       }
 
-      throw new Error('Property not found.')
+      throw new Error(`Property ${property} not found.`)
     } else {
-      throw new Error('Property should be an instance of property class.')
+      throw new Error(`Property ${property} should be an instance of property class.`)
     }
   }
 
   hasProperty(property) {
     if (property instanceof Property || typeof property === 'string') {
       if (property instanceof Property && !property.id) {
-        throw new Error('Property does not have an ID.')
+        throw new Error(`Property ${property} does not have an ID.`)
       }
 
       for (let i = 0; i < this._propertys.length; i++) {
@@ -196,7 +196,7 @@ class Component {
       }
       return false
     } else {
-      throw new Error('propertys should be an instance of Property class.')
+      throw new Error(`Property ${property} should be an instance of property class.`)
     }
   }
 


### PR DESCRIPTION
#### Description:
This PR adds the name of the property whose lookup failed in component property methods, to the error message thrown.
#### Fix:
This PR replaces adds a property name to the error messages thrown in component property methods lookups for `Component.js`.
#### Rationale:
When building graph components, a developer often adds multiple properties to `Component`. Sometimes, when executing the components or as in my case, testing them, a developer might send wrong property names that are not the ones the component expects.
This PR makes the error clearer by outputting the offending property name, thus making the error easier to debug and fix.