### PR TITLE
Optional properties to graph

### DIFF
--- a/src/Graph.js
+++ b/src/Graph.js
@@ -145,12 +145,12 @@ class Graph {
     var targetComponent = this._components[targetComponentId]
     targetComponent._propertys.forEach(property => {
       // resolve path
-      // check that component is required before accessing port componentId and propertyId
+      // check that the property's data is present before accessing port componentId and propertyId
       // this change was made to allow for optional properties
       const _resolvePath = resolvePath(property.data)
-      const componentId = property._required && _resolvePath.componentId
-      const portId = property._required && _resolvePath.portId
-      const propertyId = property._required && _resolvePath.propertyId
+      const componentId = property.data && _resolvePath.componentId
+      const portId = property.data && _resolvePath.portId
+      const propertyId = property.data && _resolvePath.propertyId
 
       // if resolved
       if (componentId && portId && propertyId) {

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -145,12 +145,12 @@ class Graph {
     var targetComponent = this._components[targetComponentId]
     targetComponent._propertys.forEach(property => {
       // resolve path
-      // check that component has property data before accessing port componentId and propertyId
+      // check that component is required before accessing port componentId and propertyId
       // this change was made to allow for optional properties
       const _resolvePath = resolvePath(property.data)
-      const componentId = _resolvePath && _resolvePath.componentId
-      const portId = _resolvePath && _resolvePath.portId
-      const propertyId = _resolvePath && _resolvePath.propertyId
+      const componentId = property._required && _resolvePath.componentId
+      const portId = property._required && _resolvePath.portId
+      const propertyId = property._required && _resolvePath.propertyId
 
       // if resolved
       if (componentId && portId && propertyId) {

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -145,8 +145,12 @@ class Graph {
     var targetComponent = this._components[targetComponentId]
     targetComponent._propertys.forEach(property => {
       // resolve path
-
-      const { componentId, portId, propertyId } = resolvePath(property.data)
+      // check that component has property data before accessing port componentId and propertyId
+      // this change was made to allow for optional properties
+      const _resolvePath = resolvePath(property.data)
+      const componentId = _resolvePath && _resolvePath.componentId
+      const portId = _resolvePath && _resolvePath.portId
+      const propertyId = _resolvePath && _resolvePath.propertyId
 
       // if resolved
       if (componentId && portId && propertyId) {


### PR DESCRIPTION
#### Description:
This PR enables allowing optional component properties when connecting to a graph.
#### Fix:
This PR adds a check per component property for whether the property property data exists, before attempting to resolve the path. This happens when the component is on a graph.
#### Rationale:
The graph component `resolveProperties` method does not check whether the component property is required before attempting to resolve component properties. This causes a bug where the graph component attempts to resolve `componentId`, `portId`, and `propertyId` on an `undefined` property. This breaks the app.